### PR TITLE
When goinmg to base url navlink for studies is highlighted

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -65,7 +65,9 @@ function ResponsiveAppBar() {
   const handleCloseNavMenu = () => setAnchorElNav(null);
 
   const isActive = (path) =>
-    location.pathname === path || location.pathname.startsWith(`${path}/`);
+    location.pathname === path ||
+    (path === '/studies' && location.pathname === '/') ||
+    location.pathname.startsWith(`${path}/`);
 
   const handleProfileButtonClick = () => setOpenProfileModal(true);
 


### PR DESCRIPTION
**What was done:**
- fixed so that even if the user navigates to '/' instead of '/studies', the Studies navlink will be highlighted as selected in the Header Nav Menu